### PR TITLE
Split clientbound and serverbound packets

### DIFF
--- a/azalea-client/src/client.rs
+++ b/azalea-client/src/client.rs
@@ -11,13 +11,13 @@ use azalea_protocol::{
             serverbound_accept_teleportation_packet::ServerboundAcceptTeleportationPacket,
             serverbound_custom_payload_packet::ServerboundCustomPayloadPacket,
             serverbound_keep_alive_packet::ServerboundKeepAlivePacket,
-            serverbound_move_player_packet_pos_rot::ServerboundMovePlayerPacketPosRot, GamePacket,
+            serverbound_move_player_packet_pos_rot::ServerboundMovePlayerPacketPosRot,
+            ClientboundGamePacket,
         },
         handshake::client_intention_packet::ClientIntentionPacket,
         login::{
             serverbound_hello_packet::ServerboundHelloPacket,
             serverbound_key_packet::{NonceOrSaltSignature, ServerboundKeyPacket},
-            LoginPacket,
         },
         ConnectionProtocol, PROTOCOL_VERSION,
     },
@@ -203,12 +203,12 @@ impl Client {
     }
 
     async fn handle(
-        packet: &GamePacket,
+        packet: &ClientboundGamePacket,
         client: &Client,
         tx: &UnboundedSender<Event>,
     ) -> Result<(), HandleError> {
         match packet {
-            GamePacket::ClientboundLoginPacket(p) => {
+            ClientboundGamePacket::ClientboundLoginPacket(p) => {
                 println!("Got login packet {:?}", p);
 
                 {
@@ -307,40 +307,40 @@ impl Client {
 
                 tx.send(Event::Login).unwrap();
             }
-            GamePacket::ClientboundUpdateViewDistancePacket(p) => {
+            ClientboundGamePacket::ClientboundUpdateViewDistancePacket(p) => {
                 println!("Got view distance packet {:?}", p);
             }
-            GamePacket::ClientboundCustomPayloadPacket(p) => {
+            ClientboundGamePacket::ClientboundCustomPayloadPacket(p) => {
                 println!("Got custom payload packet {:?}", p);
             }
-            GamePacket::ClientboundChangeDifficultyPacket(p) => {
+            ClientboundGamePacket::ClientboundChangeDifficultyPacket(p) => {
                 println!("Got difficulty packet {:?}", p);
             }
-            GamePacket::ClientboundDeclareCommandsPacket(_p) => {
+            ClientboundGamePacket::ClientboundDeclareCommandsPacket(_p) => {
                 println!("Got declare commands packet");
             }
-            GamePacket::ClientboundPlayerAbilitiesPacket(p) => {
+            ClientboundGamePacket::ClientboundPlayerAbilitiesPacket(p) => {
                 println!("Got player abilities packet {:?}", p);
             }
-            GamePacket::ClientboundSetCarriedItemPacket(p) => {
+            ClientboundGamePacket::ClientboundSetCarriedItemPacket(p) => {
                 println!("Got set carried item packet {:?}", p);
             }
-            GamePacket::ClientboundUpdateTagsPacket(_p) => {
+            ClientboundGamePacket::ClientboundUpdateTagsPacket(_p) => {
                 println!("Got update tags packet");
             }
-            GamePacket::ClientboundDisconnectPacket(p) => {
+            ClientboundGamePacket::ClientboundDisconnectPacket(p) => {
                 println!("Got disconnect packet {:?}", p);
             }
-            GamePacket::ClientboundUpdateRecipesPacket(_p) => {
+            ClientboundGamePacket::ClientboundUpdateRecipesPacket(_p) => {
                 println!("Got update recipes packet");
             }
-            GamePacket::ClientboundEntityEventPacket(_p) => {
+            ClientboundGamePacket::ClientboundEntityEventPacket(_p) => {
                 // println!("Got entity event packet {:?}", p);
             }
-            GamePacket::ClientboundRecipePacket(_p) => {
+            ClientboundGamePacket::ClientboundRecipePacket(_p) => {
                 println!("Got recipe packet");
             }
-            GamePacket::ClientboundPlayerPositionPacket(p) => {
+            ClientboundGamePacket::ClientboundPlayerPositionPacket(p) => {
                 // TODO: reply with teleport confirm
                 println!("Got player position packet {:?}", p);
 
@@ -432,10 +432,10 @@ impl Client {
                     )
                     .await;
             }
-            GamePacket::ClientboundPlayerInfoPacket(p) => {
+            ClientboundGamePacket::ClientboundPlayerInfoPacket(p) => {
                 println!("Got player info packet {:?}", p);
             }
-            GamePacket::ClientboundSetChunkCacheCenterPacket(p) => {
+            ClientboundGamePacket::ClientboundSetChunkCacheCenterPacket(p) => {
                 println!("Got chunk cache center packet {:?}", p);
                 client
                     .dimension
@@ -444,7 +444,7 @@ impl Client {
                     .unwrap()
                     .update_view_center(&ChunkPos::new(p.x, p.z));
             }
-            GamePacket::ClientboundLevelChunkWithLightPacket(p) => {
+            ClientboundGamePacket::ClientboundLevelChunkWithLightPacket(p) => {
                 println!("Got chunk with light packet {} {}", p.x, p.z);
                 let pos = ChunkPos::new(p.x, p.z);
                 // let chunk = Chunk::read_with_world_height(&mut p.chunk_data);
@@ -457,10 +457,10 @@ impl Client {
                     .replace_with_packet_data(&pos, &mut p.chunk_data.data.as_slice())
                     .unwrap();
             }
-            GamePacket::ClientboundLightUpdatePacket(p) => {
+            ClientboundGamePacket::ClientboundLightUpdatePacket(p) => {
                 println!("Got light update packet {:?}", p);
             }
-            GamePacket::ClientboundAddEntityPacket(p) => {
+            ClientboundGamePacket::ClientboundAddEntityPacket(p) => {
                 println!("Got add entity packet {:?}", p);
                 let entity = Entity::from(p);
                 client
@@ -470,19 +470,19 @@ impl Client {
                     .expect("Dimension doesn't exist! We should've gotten a login packet by now.")
                     .add_entity(entity);
             }
-            GamePacket::ClientboundSetEntityDataPacket(_p) => {
+            ClientboundGamePacket::ClientboundSetEntityDataPacket(_p) => {
                 // println!("Got set entity data packet {:?}", p);
             }
-            GamePacket::ClientboundUpdateAttributesPacket(_p) => {
+            ClientboundGamePacket::ClientboundUpdateAttributesPacket(_p) => {
                 // println!("Got update attributes packet {:?}", p);
             }
-            GamePacket::ClientboundEntityVelocityPacket(_p) => {
+            ClientboundGamePacket::ClientboundEntityVelocityPacket(_p) => {
                 // println!("Got entity velocity packet {:?}", p);
             }
-            GamePacket::ClientboundSetEntityLinkPacket(p) => {
+            ClientboundGamePacket::ClientboundSetEntityLinkPacket(p) => {
                 println!("Got set entity link packet {:?}", p);
             }
-            GamePacket::ClientboundAddPlayerPacket(p) => {
+            ClientboundGamePacket::ClientboundAddPlayerPacket(p) => {
                 println!("Got add player packet {:?}", p);
                 let entity = Entity::from(p);
                 client
@@ -492,25 +492,25 @@ impl Client {
                     .expect("Dimension doesn't exist! We should've gotten a login packet by now.")
                     .add_entity(entity);
             }
-            GamePacket::ClientboundInitializeBorderPacket(p) => {
+            ClientboundGamePacket::ClientboundInitializeBorderPacket(p) => {
                 println!("Got initialize border packet {:?}", p);
             }
-            GamePacket::ClientboundSetTimePacket(p) => {
+            ClientboundGamePacket::ClientboundSetTimePacket(p) => {
                 println!("Got set time packet {:?}", p);
             }
-            GamePacket::ClientboundSetDefaultSpawnPositionPacket(p) => {
+            ClientboundGamePacket::ClientboundSetDefaultSpawnPositionPacket(p) => {
                 println!("Got set default spawn position packet {:?}", p);
             }
-            GamePacket::ClientboundContainerSetContentPacket(p) => {
+            ClientboundGamePacket::ClientboundContainerSetContentPacket(p) => {
                 println!("Got container set content packet {:?}", p);
             }
-            GamePacket::ClientboundSetHealthPacket(p) => {
+            ClientboundGamePacket::ClientboundSetHealthPacket(p) => {
                 println!("Got set health packet {:?}", p);
             }
-            GamePacket::ClientboundSetExperiencePacket(p) => {
+            ClientboundGamePacket::ClientboundSetExperiencePacket(p) => {
                 println!("Got set experience packet {:?}", p);
             }
-            GamePacket::ClientboundTeleportEntityPacket(p) => {
+            ClientboundGamePacket::ClientboundTeleportEntityPacket(p) => {
                 let mut dimension_lock = client.dimension.lock()?;
                 let dimension = dimension_lock.as_mut().unwrap();
 
@@ -523,28 +523,28 @@ impl Client {
                     },
                 )?;
             }
-            GamePacket::ClientboundUpdateAdvancementsPacket(p) => {
+            ClientboundGamePacket::ClientboundUpdateAdvancementsPacket(p) => {
                 println!("Got update advancements packet {:?}", p);
             }
-            GamePacket::ClientboundRotateHeadPacket(_p) => {
+            ClientboundGamePacket::ClientboundRotateHeadPacket(_p) => {
                 // println!("Got rotate head packet {:?}", p);
             }
-            GamePacket::ClientboundMoveEntityPosPacket(p) => {
+            ClientboundGamePacket::ClientboundMoveEntityPosPacket(p) => {
                 let mut dimension_lock = client.dimension.lock()?;
                 let dimension = dimension_lock.as_mut().unwrap();
 
                 dimension.move_entity_with_delta(p.entity_id, &p.delta)?;
             }
-            GamePacket::ClientboundMoveEntityPosrotPacket(p) => {
+            ClientboundGamePacket::ClientboundMoveEntityPosrotPacket(p) => {
                 let mut dimension_lock = client.dimension.lock()?;
                 let dimension = dimension_lock.as_mut().unwrap();
 
                 dimension.move_entity_with_delta(p.entity_id, &p.delta)?;
             }
-            GamePacket::ClientboundMoveEntityRotPacket(p) => {
+            ClientboundGamePacket::ClientboundMoveEntityRotPacket(p) => {
                 println!("Got move entity rot packet {:?}", p);
             }
-            GamePacket::ClientboundKeepAlivePacket(p) => {
+            ClientboundGamePacket::ClientboundKeepAlivePacket(p) => {
                 println!("Got keep alive packet {:?}", p);
                 client
                     .conn
@@ -553,48 +553,48 @@ impl Client {
                     .write(ServerboundKeepAlivePacket { id: p.id }.get())
                     .await;
             }
-            GamePacket::ClientboundRemoveEntitiesPacket(p) => {
+            ClientboundGamePacket::ClientboundRemoveEntitiesPacket(p) => {
                 println!("Got remove entities packet {:?}", p);
             }
-            GamePacket::ClientboundPlayerChatPacket(p) => {
+            ClientboundGamePacket::ClientboundPlayerChatPacket(p) => {
                 println!("Got player chat packet {:?}", p);
                 tx.send(Event::Chat(ChatPacket::Player(Box::new(p.clone()))))
                     .unwrap();
             }
-            GamePacket::ClientboundSystemChatPacket(p) => {
+            ClientboundGamePacket::ClientboundSystemChatPacket(p) => {
                 println!("Got system chat packet {:?}", p);
                 tx.send(Event::Chat(ChatPacket::System(p.clone()))).unwrap();
             }
-            GamePacket::ClientboundSoundPacket(p) => {
+            ClientboundGamePacket::ClientboundSoundPacket(p) => {
                 println!("Got sound packet {:?}", p);
             }
-            GamePacket::ClientboundLevelEventPacket(p) => {
+            ClientboundGamePacket::ClientboundLevelEventPacket(p) => {
                 println!("Got level event packet {:?}", p);
             }
-            GamePacket::ClientboundBlockUpdatePacket(p) => {
+            ClientboundGamePacket::ClientboundBlockUpdatePacket(p) => {
                 println!("Got block update packet {:?}", p);
                 // TODO: update world
             }
-            GamePacket::ClientboundAnimatePacket(p) => {
+            ClientboundGamePacket::ClientboundAnimatePacket(p) => {
                 println!("Got animate packet {:?}", p);
             }
-            GamePacket::ClientboundSectionBlocksUpdatePacket(p) => {
+            ClientboundGamePacket::ClientboundSectionBlocksUpdatePacket(p) => {
                 println!("Got section blocks update packet {:?}", p);
                 // TODO: update world
             }
-            GamePacket::ClientboundGameEventPacket(p) => {
+            ClientboundGamePacket::ClientboundGameEventPacket(p) => {
                 println!("Got game event packet {:?}", p);
             }
-            GamePacket::ClientboundLevelParticlesPacket(p) => {
+            ClientboundGamePacket::ClientboundLevelParticlesPacket(p) => {
                 println!("Got level particles packet {:?}", p);
             }
-            GamePacket::ClientboundServerDataPacket(p) => {
+            ClientboundGamePacket::ClientboundServerDataPacket(p) => {
                 println!("Got server data packet {:?}", p);
             }
-            GamePacket::ClientboundSetEquipmentPacket(p) => {
+            ClientboundGamePacket::ClientboundSetEquipmentPacket(p) => {
                 println!("Got set equipment packet {:?}", p);
             }
-            GamePacket::ClientboundUpdateMobEffectPacket(p) => {
+            ClientboundGamePacket::ClientboundUpdateMobEffectPacket(p) => {
                 println!("Got update mob effect packet {:?}", p);
             }
             _ => panic!("Unexpected packet {:?}", packet),

--- a/azalea-client/src/client.rs
+++ b/azalea-client/src/client.rs
@@ -3,7 +3,7 @@ use azalea_auth::game_profile::GameProfile;
 use azalea_core::{ChunkPos, EntityPos, PositionDelta, PositionDeltaTrait, ResourceLocation};
 use azalea_entity::Entity;
 use azalea_protocol::{
-    connect::{GameConnection, HandshakeConnection},
+    connect::Connection,
     packets::{
         game::{
             clientbound_player_chat_packet::ClientboundPlayerChatPacket,
@@ -12,7 +12,7 @@ use azalea_protocol::{
             serverbound_custom_payload_packet::ServerboundCustomPayloadPacket,
             serverbound_keep_alive_packet::ServerboundKeepAlivePacket,
             serverbound_move_player_packet_pos_rot::ServerboundMovePlayerPacketPosRot,
-            ClientboundGamePacket,
+            ClientboundGamePacket, ServerboundGamePacket,
         },
         handshake::client_intention_packet::ClientIntentionPacket,
         login::{
@@ -61,7 +61,7 @@ pub enum ChatPacket {
 #[derive(Clone)]
 pub struct Client {
     game_profile: GameProfile,
-    pub conn: Arc<tokio::sync::Mutex<GameConnection>>,
+    pub conn: Arc<tokio::sync::Mutex<Connection<ClientboundGamePacket, ServerboundGamePacket>>>,
     pub player: Arc<Mutex<Player>>,
     pub dimension: Arc<Mutex<Option<Dimension>>>,
     // game_loop
@@ -81,7 +81,7 @@ impl Client {
     ) -> Result<(Self, UnboundedReceiver<Event>), String> {
         let resolved_address = resolver::resolve_address(address).await?;
 
-        let mut conn = HandshakeConnection::new(&resolved_address).await?;
+        let mut conn = Connection::new(&resolved_address).await?;
 
         // handshake
         conn.write(

--- a/azalea-client/src/client.rs
+++ b/azalea-client/src/client.rs
@@ -18,6 +18,7 @@ use azalea_protocol::{
         login::{
             serverbound_hello_packet::ServerboundHelloPacket,
             serverbound_key_packet::{NonceOrSaltSignature, ServerboundKeyPacket},
+            ClientboundLoginPacket,
         },
         ConnectionProtocol, PROTOCOL_VERSION,
     },
@@ -110,7 +111,7 @@ impl Client {
             let packet_result = conn.read().await;
             match packet_result {
                 Ok(packet) => match packet {
-                    LoginPacket::ClientboundHelloPacket(p) => {
+                    ClientboundLoginPacket::ClientboundHelloPacket(p) => {
                         println!("Got encryption request");
                         let e = azalea_crypto::encrypt(&p.public_key, &p.nonce).unwrap();
 
@@ -128,21 +129,20 @@ impl Client {
                         .await;
                         conn.set_encryption_key(e.secret_key);
                     }
-                    LoginPacket::ClientboundLoginCompressionPacket(p) => {
+                    ClientboundLoginPacket::ClientboundLoginCompressionPacket(p) => {
                         println!("Got compression request {:?}", p.compression_threshold);
                         conn.set_compression_threshold(p.compression_threshold);
                     }
-                    LoginPacket::ClientboundGameProfilePacket(p) => {
+                    ClientboundLoginPacket::ClientboundGameProfilePacket(p) => {
                         println!("Got profile {:?}", p.game_profile);
                         break (conn.game(), p.game_profile);
                     }
-                    LoginPacket::ClientboundLoginDisconnectPacket(p) => {
+                    ClientboundLoginPacket::ClientboundLoginDisconnectPacket(p) => {
                         println!("Got disconnect {:?}", p);
                     }
-                    LoginPacket::ClientboundCustomQueryPacket(p) => {
+                    ClientboundLoginPacket::ClientboundCustomQueryPacket(p) => {
                         println!("Got custom query {:?}", p);
                     }
-                    _ => panic!("Unexpected packet {:?}", packet),
                 },
                 Err(e) => {
                     panic!("Error: {:?}", e);

--- a/azalea-client/src/ping.rs
+++ b/azalea-client/src/ping.rs
@@ -5,7 +5,8 @@ use azalea_protocol::{
         handshake::client_intention_packet::ClientIntentionPacket,
         status::{
             clientbound_status_response_packet::ClientboundStatusResponsePacket,
-            serverbound_status_request_packet::ServerboundStatusRequestPacket, StatusPacket,
+            serverbound_status_request_packet::ServerboundStatusRequestPacket,
+            ClientboundStatusPacket,
         },
         ConnectionProtocol, PROTOCOL_VERSION,
     },
@@ -38,7 +39,6 @@ pub async fn ping_server(
     let packet = conn.read().await.unwrap();
 
     match packet {
-        StatusPacket::ClientboundStatusResponsePacket(p) => Ok(p),
-        _ => Err("Invalid packet type".to_string()),
+        ClientboundStatusPacket::ClientboundStatusResponsePacket(p) => Ok(p),
     }
 }

--- a/azalea-client/src/ping.rs
+++ b/azalea-client/src/ping.rs
@@ -1,6 +1,6 @@
 ///! Ping Minecraft servers.
 use azalea_protocol::{
-    connect::HandshakeConnection,
+    connect::Connection,
     packets::{
         handshake::client_intention_packet::ClientIntentionPacket,
         status::{
@@ -18,7 +18,7 @@ pub async fn ping_server(
 ) -> Result<ClientboundStatusResponsePacket, String> {
     let resolved_address = resolver::resolve_address(address).await?;
 
-    let mut conn = HandshakeConnection::new(&resolved_address).await?;
+    let mut conn = Connection::new(&resolved_address).await?;
 
     // send the client intention packet and switch to the status state
     conn.write(

--- a/azalea-protocol/README.md
+++ b/azalea-protocol/README.md
@@ -12,7 +12,7 @@ Unfortunately, using azalea-protocol requires Rust nightly because [specializati
 
 Adding new packets is usually pretty easy, but you'll want to have Minecraft's decompiled source code which you can obtain with tools such as [DecompilerMC](https://github.com/hube12/DecompilerMC).
 
-1. First, you'll need the packet id. You can get this from azalea-protocol error messages, or from wiki.vg.
+1. First, you'll need the packet id. You can get this from azalea-protocol error messages or from wiki.vg.
 2. Run `python codegen/newpacket.py [packet id] [clientbound or serverbound] \[game/handshake/login/status\]`\
 3. Go to the directory where it told you the packet was generated. If there's no comments, you're done. Otherwise, keep going.
 4. Find the packet in Minecraft's source code. Minecraft's packets are in the `net/minecraft/network/protocol/<state>` directory. The state for your packet is usually `game`.

--- a/azalea-protocol/src/connect.rs
+++ b/azalea-protocol/src/connect.rs
@@ -82,10 +82,6 @@ impl Connection<ClientboundHandshakePacket, ServerboundHandshakePacket> {
     }
 }
 
-impl Connection<ClientboundGamePacket, ServerboundGamePacket> {}
-
-impl Connection<ClientboundStatusPacket, ServerboundStatusPacket> {}
-
 impl Connection<ClientboundLoginPacket, ServerboundLoginPacket> {
     pub fn set_compression_threshold(&mut self, threshold: i32) {
         // if you pass a threshold of 0 or less, compression is disabled

--- a/azalea-protocol/src/connect.rs
+++ b/azalea-protocol/src/connect.rs
@@ -1,29 +1,21 @@
 //! parse sending and receiving packets with a server.
 
-use crate::packets::game::GamePacket;
-use crate::packets::handshake::HandshakePacket;
-use crate::packets::login::LoginPacket;
-use crate::packets::status::StatusPacket;
+use crate::packets::game::{ClientboundGamePacket, ServerboundGamePacket};
+use crate::packets::handshake::{ClientboundHandshakePacket, ServerboundHandshakePacket};
+use crate::packets::login::{ClientboundLoginPacket, ServerboundLoginPacket};
+use crate::packets::status::{ClientboundStatusPacket, ServerboundStatusPacket};
 use crate::read::read_packet;
 use crate::write::write_packet;
 use crate::ServerIpAddress;
 use azalea_crypto::{Aes128CfbDec, Aes128CfbEnc};
 use tokio::net::TcpStream;
 
-#[derive(Debug, Clone, Copy)]
-pub enum PacketFlow {
-    ClientToServer,
-    ServerToClient,
-}
-
 pub struct HandshakeConnection {
-    pub flow: PacketFlow,
     /// The buffered writer
     pub stream: TcpStream,
 }
 
 pub struct GameConnection {
-    pub flow: PacketFlow,
     /// The buffered writer
     pub stream: TcpStream,
     pub compression_threshold: Option<u32>,
@@ -32,13 +24,11 @@ pub struct GameConnection {
 }
 
 pub struct StatusConnection {
-    pub flow: PacketFlow,
     /// The buffered writer
     pub stream: TcpStream,
 }
 
 pub struct LoginConnection {
-    pub flow: PacketFlow,
     /// The buffered writer
     pub stream: TcpStream,
     pub compression_threshold: Option<u32>,
@@ -60,15 +50,11 @@ impl HandshakeConnection {
             .set_nodelay(true)
             .expect("Error enabling tcp_nodelay");
 
-        Ok(HandshakeConnection {
-            flow: PacketFlow::ServerToClient,
-            stream,
-        })
+        Ok(HandshakeConnection { stream })
     }
 
     pub fn login(self) -> LoginConnection {
         LoginConnection {
-            flow: self.flow,
             stream: self.stream,
             compression_threshold: None,
             enc_cipher: None,
@@ -78,25 +64,23 @@ impl HandshakeConnection {
 
     pub fn status(self) -> StatusConnection {
         StatusConnection {
-            flow: self.flow,
             stream: self.stream,
         }
     }
 
-    pub async fn read(&mut self) -> Result<HandshakePacket, String> {
-        read_packet::<HandshakePacket, _>(&self.flow, &mut self.stream, None, &mut None).await
+    pub async fn read(&mut self) -> Result<ClientboundHandshakePacket, String> {
+        read_packet::<ClientboundHandshakePacket, _>(&mut self.stream, None, &mut None).await
     }
 
     /// Write a packet to the server
-    pub async fn write(&mut self, packet: HandshakePacket) {
+    pub async fn write(&mut self, packet: ServerboundHandshakePacket) {
         write_packet(packet, &mut self.stream, None, &mut None).await;
     }
 }
 
 impl GameConnection {
-    pub async fn read(&mut self) -> Result<GamePacket, String> {
-        read_packet::<GamePacket, _>(
-            &self.flow,
+    pub async fn read(&mut self) -> Result<ClientboundGamePacket, String> {
+        read_packet::<ClientboundGamePacket, _>(
             &mut self.stream,
             self.compression_threshold,
             &mut self.dec_cipher,
@@ -105,7 +89,7 @@ impl GameConnection {
     }
 
     /// Write a packet to the server
-    pub async fn write(&mut self, packet: GamePacket) {
+    pub async fn write(&mut self, packet: ServerboundGamePacket) {
         write_packet(
             packet,
             &mut self.stream,
@@ -117,20 +101,19 @@ impl GameConnection {
 }
 
 impl StatusConnection {
-    pub async fn read(&mut self) -> Result<StatusPacket, String> {
-        read_packet::<StatusPacket, _>(&self.flow, &mut self.stream, None, &mut None).await
+    pub async fn read(&mut self) -> Result<ClientboundStatusPacket, String> {
+        read_packet::<ClientboundStatusPacket, _>(&mut self.stream, None, &mut None).await
     }
 
     /// Write a packet to the server
-    pub async fn write(&mut self, packet: StatusPacket) {
+    pub async fn write(&mut self, packet: ServerboundStatusPacket) {
         write_packet(packet, &mut self.stream, None, &mut None).await;
     }
 }
 
 impl LoginConnection {
-    pub async fn read(&mut self) -> Result<LoginPacket, String> {
-        read_packet::<LoginPacket, _>(
-            &self.flow,
+    pub async fn read(&mut self) -> Result<ClientboundLoginPacket, String> {
+        read_packet::<ClientboundLoginPacket, _>(
             &mut self.stream,
             self.compression_threshold,
             &mut self.dec_cipher,
@@ -139,7 +122,7 @@ impl LoginConnection {
     }
 
     /// Write a packet to the server
-    pub async fn write(&mut self, packet: LoginPacket) {
+    pub async fn write(&mut self, packet: ServerboundLoginPacket) {
         write_packet(
             packet,
             &mut self.stream,
@@ -167,7 +150,6 @@ impl LoginConnection {
 
     pub fn game(self) -> GameConnection {
         GameConnection {
-            flow: self.flow,
             stream: self.stream,
             compression_threshold: self.compression_threshold,
             enc_cipher: self.enc_cipher,

--- a/azalea-protocol/src/connect.rs
+++ b/azalea-protocol/src/connect.rs
@@ -74,25 +74,11 @@ impl Connection<ClientboundHandshakePacket, ServerboundHandshakePacket> {
     }
 
     pub fn login(self) -> Connection<ClientboundLoginPacket, ServerboundLoginPacket> {
-        Connection {
-            stream: self.stream,
-            compression_threshold: self.compression_threshold,
-            enc_cipher: self.enc_cipher,
-            dec_cipher: self.dec_cipher,
-            _reading: PhantomData,
-            _writing: PhantomData,
-        }
+        Connection::from(self)
     }
 
     pub fn status(self) -> Connection<ClientboundStatusPacket, ServerboundStatusPacket> {
-        Connection {
-            stream: self.stream,
-            compression_threshold: self.compression_threshold,
-            enc_cipher: self.enc_cipher,
-            dec_cipher: self.dec_cipher,
-            _reading: PhantomData,
-            _writing: PhantomData,
-        }
+        Connection::from(self)
     }
 }
 
@@ -118,11 +104,27 @@ impl Connection<ClientboundLoginPacket, ServerboundLoginPacket> {
     }
 
     pub fn game(self) -> Connection<ClientboundGamePacket, ServerboundGamePacket> {
+        Connection::from(self)
+    }
+}
+
+// rust doesn't let us implement From because allegedly it conflicts with
+// `core`'s "impl<T> From<T> for T" so we do this instead
+impl<R1, W1> Connection<R1, W1>
+where
+    R1: ProtocolPacket + Debug,
+    W1: ProtocolPacket + Debug,
+{
+    fn from<R2, W2>(connection: Connection<R1, W1>) -> Connection<R2, W2>
+    where
+        R2: ProtocolPacket + Debug,
+        W2: ProtocolPacket + Debug,
+    {
         Connection {
-            stream: self.stream,
-            compression_threshold: self.compression_threshold,
-            enc_cipher: self.enc_cipher,
-            dec_cipher: self.dec_cipher,
+            stream: connection.stream,
+            compression_threshold: connection.compression_threshold,
+            enc_cipher: connection.enc_cipher,
+            dec_cipher: connection.dec_cipher,
             _reading: PhantomData,
             _writing: PhantomData,
         }

--- a/azalea-protocol/src/connect.rs
+++ b/azalea-protocol/src/connect.rs
@@ -4,40 +4,58 @@ use crate::packets::game::{ClientboundGamePacket, ServerboundGamePacket};
 use crate::packets::handshake::{ClientboundHandshakePacket, ServerboundHandshakePacket};
 use crate::packets::login::{ClientboundLoginPacket, ServerboundLoginPacket};
 use crate::packets::status::{ClientboundStatusPacket, ServerboundStatusPacket};
+use crate::packets::ProtocolPacket;
 use crate::read::read_packet;
 use crate::write::write_packet;
 use crate::ServerIpAddress;
 use azalea_crypto::{Aes128CfbDec, Aes128CfbEnc};
+use std::fmt::Debug;
+use std::marker::PhantomData;
 use tokio::net::TcpStream;
 
-pub struct HandshakeConnection {
-    /// The buffered writer
-    pub stream: TcpStream,
-}
+pub struct Handshake;
+pub struct Game;
+pub struct Status;
+pub struct Login;
 
-pub struct GameConnection {
-    /// The buffered writer
-    pub stream: TcpStream,
-    pub compression_threshold: Option<u32>,
-    pub enc_cipher: Option<Aes128CfbEnc>,
-    pub dec_cipher: Option<Aes128CfbDec>,
-}
-
-pub struct StatusConnection {
-    /// The buffered writer
-    pub stream: TcpStream,
-}
-
-pub struct LoginConnection {
+pub struct Connection<R: ProtocolPacket, W: ProtocolPacket> {
     /// The buffered writer
     pub stream: TcpStream,
     pub compression_threshold: Option<u32>,
     pub enc_cipher: Option<Aes128CfbEnc>,
     pub dec_cipher: Option<Aes128CfbDec>,
+    _reading: PhantomData<R>,
+    _writing: PhantomData<W>,
 }
 
-impl HandshakeConnection {
-    pub async fn new(address: &ServerIpAddress) -> Result<HandshakeConnection, String> {
+impl<R, W> Connection<R, W>
+where
+    R: ProtocolPacket + Debug,
+    W: ProtocolPacket + Debug,
+{
+    pub async fn read(&mut self) -> Result<R, String> {
+        read_packet::<R, _>(
+            &mut self.stream,
+            self.compression_threshold,
+            &mut self.dec_cipher,
+        )
+        .await
+    }
+
+    /// Write a packet to the server
+    pub async fn write(&mut self, packet: W) {
+        write_packet(
+            packet,
+            &mut self.stream,
+            self.compression_threshold,
+            &mut self.enc_cipher,
+        )
+        .await;
+    }
+}
+
+impl Connection<ClientboundHandshakePacket, ServerboundHandshakePacket> {
+    pub async fn new(address: &ServerIpAddress) -> Result<Self, String> {
         let ip = address.ip;
         let port = address.port;
 
@@ -50,88 +68,44 @@ impl HandshakeConnection {
             .set_nodelay(true)
             .expect("Error enabling tcp_nodelay");
 
-        Ok(HandshakeConnection { stream })
-    }
-
-    pub fn login(self) -> LoginConnection {
-        LoginConnection {
-            stream: self.stream,
+        Ok(Connection {
+            stream,
             compression_threshold: None,
             enc_cipher: None,
             dec_cipher: None,
-        }
+            _reading: PhantomData,
+            _writing: PhantomData,
+        })
     }
 
-    pub fn status(self) -> StatusConnection {
-        StatusConnection {
+    pub fn login(self) -> Connection<ClientboundLoginPacket, ServerboundLoginPacket> {
+        Connection {
             stream: self.stream,
+            compression_threshold: self.compression_threshold,
+            enc_cipher: self.enc_cipher,
+            dec_cipher: self.dec_cipher,
+            _reading: PhantomData,
+            _writing: PhantomData,
         }
     }
 
-    pub async fn read(&mut self) -> Result<ClientboundHandshakePacket, String> {
-        read_packet::<ClientboundHandshakePacket, _>(&mut self.stream, None, &mut None).await
-    }
-
-    /// Write a packet to the server
-    pub async fn write(&mut self, packet: ServerboundHandshakePacket) {
-        write_packet(packet, &mut self.stream, None, &mut None).await;
-    }
-}
-
-impl GameConnection {
-    pub async fn read(&mut self) -> Result<ClientboundGamePacket, String> {
-        read_packet::<ClientboundGamePacket, _>(
-            &mut self.stream,
-            self.compression_threshold,
-            &mut self.dec_cipher,
-        )
-        .await
-    }
-
-    /// Write a packet to the server
-    pub async fn write(&mut self, packet: ServerboundGamePacket) {
-        write_packet(
-            packet,
-            &mut self.stream,
-            self.compression_threshold,
-            &mut self.enc_cipher,
-        )
-        .await;
+    pub fn status(self) -> Connection<ClientboundStatusPacket, ServerboundStatusPacket> {
+        Connection {
+            stream: self.stream,
+            compression_threshold: self.compression_threshold,
+            enc_cipher: self.enc_cipher,
+            dec_cipher: self.dec_cipher,
+            _reading: PhantomData,
+            _writing: PhantomData,
+        }
     }
 }
 
-impl StatusConnection {
-    pub async fn read(&mut self) -> Result<ClientboundStatusPacket, String> {
-        read_packet::<ClientboundStatusPacket, _>(&mut self.stream, None, &mut None).await
-    }
+impl Connection<ClientboundGamePacket, ServerboundGamePacket> {}
 
-    /// Write a packet to the server
-    pub async fn write(&mut self, packet: ServerboundStatusPacket) {
-        write_packet(packet, &mut self.stream, None, &mut None).await;
-    }
-}
+impl Connection<ClientboundStatusPacket, ServerboundStatusPacket> {}
 
-impl LoginConnection {
-    pub async fn read(&mut self) -> Result<ClientboundLoginPacket, String> {
-        read_packet::<ClientboundLoginPacket, _>(
-            &mut self.stream,
-            self.compression_threshold,
-            &mut self.dec_cipher,
-        )
-        .await
-    }
-
-    /// Write a packet to the server
-    pub async fn write(&mut self, packet: ServerboundLoginPacket) {
-        write_packet(
-            packet,
-            &mut self.stream,
-            self.compression_threshold,
-            &mut self.enc_cipher,
-        )
-        .await;
-    }
-
+impl Connection<ClientboundLoginPacket, ServerboundLoginPacket> {
     pub fn set_compression_threshold(&mut self, threshold: i32) {
         // if you pass a threshold of 0 or less, compression is disabled
         if threshold > 0 {
@@ -148,12 +122,14 @@ impl LoginConnection {
         self.dec_cipher = Some(dec_cipher);
     }
 
-    pub fn game(self) -> GameConnection {
-        GameConnection {
+    pub fn game(self) -> Connection<ClientboundGamePacket, ServerboundGamePacket> {
+        Connection {
             stream: self.stream,
             compression_threshold: self.compression_threshold,
             enc_cipher: self.enc_cipher,
             dec_cipher: self.dec_cipher,
+            _reading: PhantomData,
+            _writing: PhantomData,
         }
     }
 }

--- a/azalea-protocol/src/connect.rs
+++ b/azalea-protocol/src/connect.rs
@@ -13,11 +13,6 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use tokio::net::TcpStream;
 
-pub struct Handshake;
-pub struct Game;
-pub struct Status;
-pub struct Login;
-
 pub struct Connection<R: ProtocolPacket, W: ProtocolPacket> {
     /// The buffered writer
     pub stream: TcpStream,

--- a/azalea-protocol/src/packets/game/clientbound_add_entity_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_add_entity_packet.rs
@@ -1,10 +1,10 @@
 use azalea_buf::McBuf;
 use azalea_core::EntityPos;
 use azalea_entity::Entity;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use uuid::Uuid;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundAddEntityPacket {
     /// The id of the entity.
     #[var]

--- a/azalea-protocol/src/packets/game/clientbound_add_player_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_add_player_packet.rs
@@ -1,11 +1,11 @@
 use azalea_buf::McBuf;
 use azalea_core::EntityPos;
 use azalea_entity::Entity;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use uuid::Uuid;
 
 /// This packet is sent by the server when a player comes into visible range, not when a player joins.
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundAddPlayerPacket {
     #[var]
     pub id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_animate_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_animate_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundAnimatePacket {
     #[var]
     pub id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_block_changed_ack_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_block_changed_ack_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundBlockChangedAckPacket {
     #[var]
     pub sequence: i32,

--- a/azalea-protocol/src/packets/game/clientbound_block_update_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_block_update_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_core::BlockPos;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundBlockUpdatePacket {
     pub pos: BlockPos,
     // TODO: in vanilla this is a BlockState, but here we just have it as a number.

--- a/azalea-protocol/src/packets/game/clientbound_change_difficulty_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_change_difficulty_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_core::Difficulty;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundChangeDifficultyPacket {
     pub difficulty: Difficulty,
     pub locked: bool,

--- a/azalea-protocol/src/packets/game/clientbound_chat_preview_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_chat_preview_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_chat::component::Component;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundChatPreviewPacket {
     pub query_id: i32,
     pub preview: Option<Component>,

--- a/azalea-protocol/src/packets/game/clientbound_container_set_content_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_container_set_content_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_core::Slot;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundContainerSetContentPacket {
     pub container_id: u8,
     #[var]

--- a/azalea-protocol/src/packets/game/clientbound_custom_chat_completions_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_custom_chat_completions_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundCustomChatCompletionsPacket {
     pub action: Action,
     pub entries: Vec<String>,

--- a/azalea-protocol/src/packets/game/clientbound_custom_payload_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_custom_payload_packet.rs
@@ -1,9 +1,9 @@
 use azalea_buf::McBuf;
 use azalea_buf::UnsizedByteArray;
 use azalea_core::ResourceLocation;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundCustomPayloadPacket {
     pub identifier: ResourceLocation,
     pub data: UnsizedByteArray,

--- a/azalea-protocol/src/packets/game/clientbound_declare_commands_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_declare_commands_packet.rs
@@ -2,13 +2,13 @@ use azalea_buf::McBuf;
 use azalea_buf::McBufVarReadable;
 use azalea_buf::{McBufReadable, McBufWritable, Readable, Writable};
 use azalea_core::ResourceLocation;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::{
     hash::Hash,
     io::{Read, Write},
 };
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundDeclareCommandsPacket {
     pub entries: Vec<BrigadierNodeStub>,
     #[var]

--- a/azalea-protocol/src/packets/game/clientbound_delete_chat_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_delete_chat_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_crypto::MessageSignature;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundDeleteChatPacket {
     pub message_signature: MessageSignature,
 }

--- a/azalea-protocol/src/packets/game/clientbound_disconnect_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_disconnect_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_chat::component::Component;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundDisconnectPacket {
     pub reason: Component,
 }

--- a/azalea-protocol/src/packets/game/clientbound_entity_event_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_entity_event_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
 // we can't identify the status in azalea-protocol since they vary depending on the entity
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundEntityEventPacket {
     pub entity_id: u32,
     pub event_id: u8,

--- a/azalea-protocol/src/packets/game/clientbound_entity_velocity_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_entity_velocity_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundEntityVelocityPacket {
     #[var]
     pub entity_id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_game_event_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_game_event_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundGameEventPacket {
     pub event: EventType,
     pub param: f32,

--- a/azalea-protocol/src/packets/game/clientbound_initialize_border_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_initialize_border_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundInitializeBorderPacket {
     pub new_center_x: f64,
     pub new_center_z: f64,

--- a/azalea-protocol/src/packets/game/clientbound_keep_alive_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_keep_alive_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundKeepAlivePacket {
     pub id: u64,
 }

--- a/azalea-protocol/src/packets/game/clientbound_level_chunk_with_light_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_level_chunk_with_light_packet.rs
@@ -1,9 +1,9 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
 use super::clientbound_light_update_packet::ClientboundLightUpdatePacketData;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundLevelChunkWithLightPacket {
     pub x: i32,
     pub z: i32,

--- a/azalea-protocol/src/packets/game/clientbound_level_event_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_level_event_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_core::BlockPos;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundLevelEventPacket {
     pub type_: i32,
     pub pos: BlockPos,

--- a/azalea-protocol/src/packets/game/clientbound_level_particles_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_level_particles_packet.rs
@@ -1,9 +1,9 @@
 use azalea_buf::{McBufReadable, McBufVarReadable, McBufWritable};
 use azalea_core::ParticleData;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::io::{Read, Write};
 
-#[derive(Clone, Debug, GamePacket)]
+#[derive(Clone, Debug, ClientboundGamePacket)]
 pub struct ClientboundLevelParticlesPacket {
     #[var]
     pub particle_id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_light_update_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_light_update_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::{BitSet, McBuf};
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundLightUpdatePacket {
     pub x: i32,
     pub z: i32,

--- a/azalea-protocol/src/packets/game/clientbound_login_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_login_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_core::{GameType, GlobalPos, OptionalGameType, ResourceLocation};
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundLoginPacket {
     pub player_id: u32,
     pub hardcore: bool,

--- a/azalea-protocol/src/packets/game/clientbound_move_entity_pos_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_move_entity_pos_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_core::PositionDelta8;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundMoveEntityPosPacket {
     #[var]
     pub entity_id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_move_entity_posrot_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_move_entity_posrot_packet.rs
@@ -1,9 +1,9 @@
 use azalea_buf::McBuf;
 use azalea_core::PositionDelta8;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
 /// This packet is sent by the server when an entity moves less then 8 blocks.
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundMoveEntityPosrotPacket {
     #[var]
     pub entity_id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_move_entity_rot_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_move_entity_rot_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundMoveEntityRotPacket {
     #[var]
     pub entity_id: i32,

--- a/azalea-protocol/src/packets/game/clientbound_player_abilities_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_player_abilities_packet.rs
@@ -1,9 +1,9 @@
 use azalea_buf::McBuf;
 use azalea_buf::{McBufReadable, McBufWritable, Readable};
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::io::{Read, Write};
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundPlayerAbilitiesPacket {
     pub flags: PlayerAbilitiesFlags,
     pub flying_speed: f32,

--- a/azalea-protocol/src/packets/game/clientbound_player_chat_header_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_player_chat_header_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_crypto::{MessageSignature, SignedMessageHeader};
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundPlayerChatHeaderPacket {
     pub header: SignedMessageHeader,
     pub header_signature: MessageSignature,

--- a/azalea-protocol/src/packets/game/clientbound_player_chat_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_player_chat_packet.rs
@@ -2,11 +2,11 @@ use azalea_buf::{BitSet, McBuf, McBufReadable, McBufVarWritable};
 use azalea_buf::{McBufVarReadable, McBufWritable};
 use azalea_chat::component::Component;
 use azalea_crypto::{MessageSignature, SignedMessageHeader};
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::io::{Read, Write};
 use uuid::Uuid;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundPlayerChatPacket {
     pub message: PlayerChatMessage,
     pub chat_type: ChatTypeBound,

--- a/azalea-protocol/src/packets/game/clientbound_player_info_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_player_info_packet.rs
@@ -1,11 +1,11 @@
 use azalea_buf::McBuf;
 use azalea_buf::{McBufReadable, McBufWritable, Readable, Writable};
 use azalea_chat::component::Component;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::io::{Read, Write};
 use uuid::Uuid;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundPlayerInfoPacket {
     pub action: Action,
 }

--- a/azalea-protocol/src/packets/game/clientbound_player_position_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_player_position_packet.rs
@@ -1,9 +1,9 @@
 use azalea_buf::McBuf;
 use azalea_buf::{McBufReadable, McBufWritable, Readable};
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::io::{Read, Write};
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundPlayerPositionPacket {
     pub x: f64,
     pub y: f64,

--- a/azalea-protocol/src/packets/game/clientbound_recipe_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_recipe_packet.rs
@@ -1,10 +1,10 @@
 use azalea_buf::McBuf;
 use azalea_buf::{McBufReadable, McBufWritable, Readable, Writable};
 use azalea_core::ResourceLocation;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::io::{Read, Write};
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundRecipePacket {
     pub action: State,
     pub settings: RecipeBookSettings,

--- a/azalea-protocol/src/packets/game/clientbound_remove_entities_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_remove_entities_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundRemoveEntitiesPacket {
     #[var]
     pub entity_ids: Vec<u32>,

--- a/azalea-protocol/src/packets/game/clientbound_rotate_head_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_rotate_head_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundRotateHeadPacket {
     #[var]
     pub entity_id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_section_blocks_update_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_section_blocks_update_packet.rs
@@ -1,10 +1,10 @@
 use azalea_buf::McBuf;
 use azalea_buf::{McBufReadable, McBufVarReadable, McBufVarWritable, McBufWritable};
 use azalea_core::{ChunkSectionBlockPos, ChunkSectionPos};
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::io::{Read, Write};
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSectionBlocksUpdatePacket {
     pub section_pos: ChunkSectionPos,
     pub suppress_light_updates: bool,

--- a/azalea-protocol/src/packets/game/clientbound_server_data_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_server_data_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_chat::component::Component;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundServerDataPacket {
     pub motd: Option<Component>,
     pub icon_base64: Option<String>,

--- a/azalea-protocol/src/packets/game/clientbound_set_carried_item_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_set_carried_item_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
 /// Sent to change the player's slot selection.
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSetCarriedItemPacket {
     pub slot: u8,
 }

--- a/azalea-protocol/src/packets/game/clientbound_set_chunk_cache_center_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_set_chunk_cache_center_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSetChunkCacheCenterPacket {
     #[var]
     pub x: i32,

--- a/azalea-protocol/src/packets/game/clientbound_set_default_spawn_position_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_set_default_spawn_position_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_core::BlockPos;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSetDefaultSpawnPositionPacket {
     pub pos: BlockPos,
     pub angle: f32,

--- a/azalea-protocol/src/packets/game/clientbound_set_display_chat_preview_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_set_display_chat_preview_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSetDisplayChatPreviewPacket {
     pub enabled: bool,
 }

--- a/azalea-protocol/src/packets/game/clientbound_set_entity_data_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_set_entity_data_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_entity::EntityMetadata;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSetEntityDataPacket {
     #[var]
     pub id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_set_entity_link_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_set_entity_link_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSetEntityLinkPacket {
     pub source_id: u32,
     pub dest_id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_set_equipment_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_set_equipment_packet.rs
@@ -1,10 +1,10 @@
 use azalea_buf::McBuf;
 use azalea_core::Slot;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
 use azalea_buf::{McBufReadable, McBufWritable};
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSetEquipmentPacket {
     #[var]
     pub entity: i32,

--- a/azalea-protocol/src/packets/game/clientbound_set_experience_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_set_experience_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSetExperiencePacket {
     pub experience_progress: f32,
     #[var]

--- a/azalea-protocol/src/packets/game/clientbound_set_health_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_set_health_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSetHealthPacket {
     pub health: f32,
     #[var]

--- a/azalea-protocol/src/packets/game/clientbound_set_time_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_set_time_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSetTimePacket {
     pub game_time: u64,
     pub day_time: u64,

--- a/azalea-protocol/src/packets/game/clientbound_sound_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_sound_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSoundPacket {
     #[var]
     // TODO: use the sound registry instead of just being a u32

--- a/azalea-protocol/src/packets/game/clientbound_system_chat_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_system_chat_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_chat::component::Component;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundSystemChatPacket {
     pub content: Component,
     pub overlay: bool,

--- a/azalea-protocol/src/packets/game/clientbound_teleport_entity_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_teleport_entity_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundTeleportEntityPacket {
     #[var]
     pub id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_update_advancements_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_update_advancements_packet.rs
@@ -1,13 +1,13 @@
 use azalea_buf::{McBuf, McBufReadable, McBufWritable};
 use azalea_chat::component::Component;
 use azalea_core::{ResourceLocation, Slot};
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::{
     collections::HashMap,
     io::{Read, Write},
 };
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundUpdateAdvancementsPacket {
     pub reset: bool,
     pub added: HashMap<ResourceLocation, Advancement>,

--- a/azalea-protocol/src/packets/game/clientbound_update_attributes_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_update_attributes_packet.rs
@@ -1,11 +1,11 @@
 use azalea_buf::McBuf;
 use azalea_buf::{McBufReadable, McBufWritable, Readable, Writable};
 use azalea_core::ResourceLocation;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::io::{Read, Write};
 use uuid::Uuid;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundUpdateAttributesPacket {
     #[var]
     pub entity_id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_update_mob_effect_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_update_mob_effect_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundUpdateMobEffectPacket {
     #[var]
     pub entity_id: u32,

--- a/azalea-protocol/src/packets/game/clientbound_update_recipes_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_update_recipes_packet.rs
@@ -2,11 +2,11 @@ use std::io::{Read, Write};
 
 use azalea_buf::McBuf;
 use azalea_core::{ResourceLocation, Slot};
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
 use azalea_buf::{McBufReadable, McBufWritable, Readable, Writable};
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundUpdateRecipesPacket {
     pub recipes: Vec<Recipe>,
 }

--- a/azalea-protocol/src/packets/game/clientbound_update_tags_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_update_tags_packet.rs
@@ -1,14 +1,14 @@
 use azalea_buf::McBuf;
 use azalea_buf::{McBufReadable, McBufWritable, Readable, Writable};
 use azalea_core::ResourceLocation;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 use std::ops::Deref;
 use std::{
     collections::HashMap,
     io::{Read, Write},
 };
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundUpdateTagsPacket {
     pub tags: TagMap,
 }

--- a/azalea-protocol/src/packets/game/clientbound_update_view_distance_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_update_view_distance_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ClientboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ClientboundGamePacket)]
 pub struct ClientboundUpdateViewDistancePacket {
     #[var]
     pub view_distance: i32,

--- a/azalea-protocol/src/packets/game/serverbound_accept_teleportation_packet.rs
+++ b/azalea-protocol/src/packets/game/serverbound_accept_teleportation_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundAcceptTeleportationPacket {
     #[var]
     pub id: u32,

--- a/azalea-protocol/src/packets/game/serverbound_chat_ack_packet.rs
+++ b/azalea-protocol/src/packets/game/serverbound_chat_ack_packet.rs
@@ -1,8 +1,8 @@
 use crate::packets::game::clientbound_player_chat_packet::LastSeenMessagesUpdate;
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundChatAckPacket {
     pub last_seen_messages: LastSeenMessagesUpdate,
 }

--- a/azalea-protocol/src/packets/game/serverbound_chat_command_packet.rs
+++ b/azalea-protocol/src/packets/game/serverbound_chat_command_packet.rs
@@ -1,10 +1,10 @@
 use azalea_buf::McBuf;
 use azalea_crypto::MessageSignature;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
 use super::clientbound_player_chat_packet::LastSeenMessagesUpdate;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundChatCommandPacket {
     pub command: String,
     // TODO: Choose a real timestamp type

--- a/azalea-protocol/src/packets/game/serverbound_chat_packet.rs
+++ b/azalea-protocol/src/packets/game/serverbound_chat_packet.rs
@@ -1,9 +1,9 @@
 use crate::packets::game::clientbound_player_chat_packet::LastSeenMessagesUpdate;
 use azalea_buf::McBuf;
 use azalea_crypto::MessageSignature;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundChatPacket {
     pub message: String,
     pub timestamp: u64,

--- a/azalea-protocol/src/packets/game/serverbound_chat_preview_packet.rs
+++ b/azalea-protocol/src/packets/game/serverbound_chat_preview_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundChatPreviewPacket {
     pub query_id: i32,
     pub query: String,

--- a/azalea-protocol/src/packets/game/serverbound_custom_payload_packet.rs
+++ b/azalea-protocol/src/packets/game/serverbound_custom_payload_packet.rs
@@ -1,9 +1,9 @@
 use azalea_buf::McBuf;
 use azalea_buf::UnsizedByteArray;
 use azalea_core::ResourceLocation;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundCustomPayloadPacket {
     pub identifier: ResourceLocation,
     pub data: UnsizedByteArray,

--- a/azalea-protocol/src/packets/game/serverbound_keep_alive_packet.rs
+++ b/azalea-protocol/src/packets/game/serverbound_keep_alive_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundKeepAlivePacket {
     pub id: u64,
 }

--- a/azalea-protocol/src/packets/game/serverbound_move_player_packet_pos.rs
+++ b/azalea-protocol/src/packets/game/serverbound_move_player_packet_pos.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundMovePlayerPacketPos {
     pub x: f64,
     pub y: f64,

--- a/azalea-protocol/src/packets/game/serverbound_move_player_packet_pos_rot.rs
+++ b/azalea-protocol/src/packets/game/serverbound_move_player_packet_pos_rot.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundMovePlayerPacketPosRot {
     pub x: f64,
     pub y: f64,

--- a/azalea-protocol/src/packets/game/serverbound_move_player_packet_rot.rs
+++ b/azalea-protocol/src/packets/game/serverbound_move_player_packet_rot.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundMovePlayerPacketRot {
     pub y_rot: f32,
     pub x_rot: f32,

--- a/azalea-protocol/src/packets/game/serverbound_move_player_packet_status_only.rs
+++ b/azalea-protocol/src/packets/game/serverbound_move_player_packet_status_only.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::GamePacket;
+use packet_macros::ServerboundGamePacket;
 
-#[derive(Clone, Debug, McBuf, GamePacket)]
+#[derive(Clone, Debug, McBuf, ServerboundGamePacket)]
 pub struct ServerboundMovePlayerPacketStatusOnly {
     pub on_ground: bool,
 }

--- a/azalea-protocol/src/packets/handshake/client_intention_packet.rs
+++ b/azalea-protocol/src/packets/handshake/client_intention_packet.rs
@@ -1,9 +1,9 @@
 use crate::packets::ConnectionProtocol;
 use azalea_buf::McBuf;
-use packet_macros::ClientboundHandshakePacket;
+use packet_macros::ServerboundHandshakePacket;
 use std::hash::Hash;
 
-#[derive(Hash, Clone, Debug, McBuf, ClientboundHandshakePacket)]
+#[derive(Hash, Clone, Debug, McBuf, ServerboundHandshakePacket)]
 pub struct ClientIntentionPacket {
     #[var]
     pub protocol_version: u32,

--- a/azalea-protocol/src/packets/handshake/client_intention_packet.rs
+++ b/azalea-protocol/src/packets/handshake/client_intention_packet.rs
@@ -1,9 +1,9 @@
 use crate::packets::ConnectionProtocol;
 use azalea_buf::McBuf;
-use packet_macros::HandshakePacket;
+use packet_macros::ClientboundHandshakePacket;
 use std::hash::Hash;
 
-#[derive(Hash, Clone, Debug, McBuf, HandshakePacket)]
+#[derive(Hash, Clone, Debug, McBuf, ClientboundHandshakePacket)]
 pub struct ClientIntentionPacket {
     #[var]
     pub protocol_version: u32,

--- a/azalea-protocol/src/packets/handshake/mod.rs
+++ b/azalea-protocol/src/packets/handshake/mod.rs
@@ -4,8 +4,8 @@ use packet_macros::declare_state_packets;
 
 declare_state_packets!(
     HandshakePacket,
-    Serverbound => {},
-    Clientbound => {
+    Serverbound => {
         0x00: client_intention_packet::ClientIntentionPacket,
-    }
+    },
+    Clientbound => {}
 );

--- a/azalea-protocol/src/packets/login/clientbound_custom_query_packet.rs
+++ b/azalea-protocol/src/packets/login/clientbound_custom_query_packet.rs
@@ -1,9 +1,9 @@
 use azalea_buf::{McBuf, UnsizedByteArray};
 use azalea_core::ResourceLocation;
-use packet_macros::LoginPacket;
+use packet_macros::ClientboundLoginPacket;
 use std::hash::Hash;
 
-#[derive(Hash, Clone, Debug, McBuf, LoginPacket)]
+#[derive(Hash, Clone, Debug, McBuf, ClientboundLoginPacket)]
 pub struct ClientboundCustomQueryPacket {
     #[var]
     pub transaction_id: u32,

--- a/azalea-protocol/src/packets/login/clientbound_game_profile_packet.rs
+++ b/azalea-protocol/src/packets/login/clientbound_game_profile_packet.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use super::LoginPacket;
+use super::ClientboundLoginPacket;
 use azalea_auth::game_profile::GameProfile;
 use azalea_buf::{McBufReadable, Readable, SerializableUuid, Writable};
 use uuid::Uuid;
@@ -12,8 +12,8 @@ pub struct ClientboundGameProfilePacket {
 
 // TODO: add derives to GameProfile and have an impl McBufReadable/Writable for GameProfile
 impl ClientboundGameProfilePacket {
-    pub fn get(self) -> LoginPacket {
-        LoginPacket::ClientboundGameProfilePacket(self)
+    pub fn get(self) -> ClientboundLoginPacket {
+        ClientboundLoginPacket::ClientboundGameProfilePacket(self)
     }
 
     pub fn write(&self, buf: &mut impl Write) -> Result<(), std::io::Error> {
@@ -24,7 +24,7 @@ impl ClientboundGameProfilePacket {
         Ok(())
     }
 
-    pub fn read(buf: &mut impl Read) -> Result<LoginPacket, String> {
+    pub fn read(buf: &mut impl Read) -> Result<ClientboundLoginPacket, String> {
         let uuid = Uuid::read_from(buf)?;
         let name = buf.read_utf_with_len(16)?;
         Ok(ClientboundGameProfilePacket {

--- a/azalea-protocol/src/packets/login/clientbound_hello_packet.rs
+++ b/azalea-protocol/src/packets/login/clientbound_hello_packet.rs
@@ -1,7 +1,7 @@
 use azalea_buf::McBuf;
-use packet_macros::LoginPacket;
+use packet_macros::ClientboundLoginPacket;
 
-#[derive(Clone, Debug, McBuf, LoginPacket)]
+#[derive(Clone, Debug, McBuf, ClientboundLoginPacket)]
 pub struct ClientboundHelloPacket {
     // TODO: make this len thing work
     // #[len(20)]

--- a/azalea-protocol/src/packets/login/clientbound_login_compression_packet.rs
+++ b/azalea-protocol/src/packets/login/clientbound_login_compression_packet.rs
@@ -5,7 +5,7 @@ use std::{
 
 use azalea_buf::{Readable, Writable};
 
-use super::LoginPacket;
+use super::ClientboundLoginPacket;
 
 #[derive(Hash, Clone, Debug)]
 pub struct ClientboundLoginCompressionPacket {
@@ -13,8 +13,8 @@ pub struct ClientboundLoginCompressionPacket {
 }
 
 impl ClientboundLoginCompressionPacket {
-    pub fn get(self) -> LoginPacket {
-        LoginPacket::ClientboundLoginCompressionPacket(self)
+    pub fn get(self) -> ClientboundLoginPacket {
+        ClientboundLoginPacket::ClientboundLoginCompressionPacket(self)
     }
 
     pub fn write(&self, buf: &mut impl Write) -> Result<(), std::io::Error> {
@@ -22,7 +22,7 @@ impl ClientboundLoginCompressionPacket {
         Ok(())
     }
 
-    pub fn read(buf: &mut impl Read) -> Result<LoginPacket, String> {
+    pub fn read(buf: &mut impl Read) -> Result<ClientboundLoginPacket, String> {
         let compression_threshold = buf.read_varint()?;
 
         Ok(ClientboundLoginCompressionPacket {

--- a/azalea-protocol/src/packets/login/clientbound_login_disconnect_packet.rs
+++ b/azalea-protocol/src/packets/login/clientbound_login_disconnect_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
 use azalea_chat::component::Component;
-use packet_macros::LoginPacket;
+use packet_macros::ClientboundLoginPacket;
 
-#[derive(Clone, Debug, McBuf, LoginPacket)]
+#[derive(Clone, Debug, McBuf, ClientboundLoginPacket)]
 pub struct ClientboundLoginDisconnectPacket {
     pub reason: Component,
 }

--- a/azalea-protocol/src/packets/login/serverbound_hello_packet.rs
+++ b/azalea-protocol/src/packets/login/serverbound_hello_packet.rs
@@ -1,8 +1,8 @@
 use azalea_buf::McBuf;
-use packet_macros::LoginPacket;
+use packet_macros::ServerboundLoginPacket;
 use uuid::Uuid;
 
-#[derive(Clone, Debug, McBuf, LoginPacket)]
+#[derive(Clone, Debug, McBuf, ServerboundLoginPacket)]
 pub struct ServerboundHelloPacket {
     pub username: String,
     pub public_key: Option<ProfilePublicKeyData>,

--- a/azalea-protocol/src/packets/login/serverbound_key_packet.rs
+++ b/azalea-protocol/src/packets/login/serverbound_key_packet.rs
@@ -1,11 +1,11 @@
 use azalea_buf::McBuf;
 use azalea_crypto::SaltSignaturePair;
-use packet_macros::LoginPacket;
+use packet_macros::ServerboundLoginPacket;
 use std::io::{Read, Write};
 
 use azalea_buf::{McBufReadable, McBufWritable};
 
-#[derive(Clone, Debug, McBuf, LoginPacket)]
+#[derive(Clone, Debug, McBuf, ServerboundLoginPacket)]
 pub struct ServerboundKeyPacket {
     pub key_bytes: Vec<u8>,
     pub nonce_or_salt_signature: NonceOrSaltSignature,

--- a/azalea-protocol/src/packets/mod.rs
+++ b/azalea-protocol/src/packets/mod.rs
@@ -3,7 +3,6 @@ pub mod handshake;
 pub mod login;
 pub mod status;
 
-use crate::connect::PacketFlow;
 use azalea_buf::{McBufWritable, Readable, Writable};
 use std::io::{Read, Write};
 
@@ -29,14 +28,6 @@ impl ConnectionProtocol {
     }
 }
 
-#[derive(Clone, Debug)]
-pub enum Packet {
-    Game(Box<game::GamePacket>),
-    Handshake(Box<handshake::HandshakePacket>),
-    Login(Box<login::LoginPacket>),
-    Status(Box<status::StatusPacket>),
-}
-
 /// An enum of packets for a certain protocol
 pub trait ProtocolPacket
 where
@@ -45,7 +36,7 @@ where
     fn id(&self) -> u32;
 
     /// Read a packet by its id, ConnectionProtocol, and flow
-    fn read(id: u32, flow: &PacketFlow, buf: &mut impl Read) -> Result<Self, String>;
+    fn read(id: u32, buf: &mut impl Read) -> Result<Self, String>;
 
     fn write(&self, buf: &mut impl Write) -> Result<(), std::io::Error>;
 }

--- a/azalea-protocol/src/packets/status/clientbound_status_response_packet.rs
+++ b/azalea-protocol/src/packets/status/clientbound_status_response_packet.rs
@@ -1,12 +1,9 @@
-use std::io::{Read, Write};
-
+use super::ClientboundStatusPacket;
+use azalea_buf::Readable;
 use azalea_chat::component::Component;
 use serde::Deserialize;
 use serde_json::Value;
-
-use azalea_buf::Readable;
-
-use super::StatusPacket;
+use std::io::{Read, Write};
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Version {
@@ -37,15 +34,15 @@ pub struct ClientboundStatusResponsePacket {
 }
 
 impl ClientboundStatusResponsePacket {
-    pub fn get(self) -> StatusPacket {
-        StatusPacket::ClientboundStatusResponsePacket(self)
+    pub fn get(self) -> ClientboundStatusPacket {
+        ClientboundStatusPacket::ClientboundStatusResponsePacket(self)
     }
 
     pub fn write(&self, _buf: &mut impl Write) -> Result<(), std::io::Error> {
         Ok(())
     }
 
-    pub fn read(buf: &mut impl Read) -> Result<StatusPacket, String> {
+    pub fn read(buf: &mut impl Read) -> Result<ClientboundStatusPacket, String> {
         let status_string = buf.read_utf()?;
         let status_json: Value =
             serde_json::from_str(status_string.as_str()).expect("Server status isn't valid JSON");

--- a/azalea-protocol/src/packets/status/serverbound_status_request_packet.rs
+++ b/azalea-protocol/src/packets/status/serverbound_status_request_packet.rs
@@ -1,5 +1,5 @@
 use azalea_buf::McBuf;
-use packet_macros::StatusPacket;
+use packet_macros::ServerboundStatusPacket;
 
-#[derive(Clone, Debug, McBuf, StatusPacket)]
+#[derive(Clone, Debug, McBuf, ServerboundStatusPacket)]
 pub struct ServerboundStatusRequestPacket {}

--- a/azalea-protocol/src/read.rs
+++ b/azalea-protocol/src/read.rs
@@ -1,4 +1,4 @@
-use crate::{connect::PacketFlow, packets::ProtocolPacket};
+use crate::packets::ProtocolPacket;
 use azalea_buf::{read_varint_async, Readable};
 use azalea_crypto::Aes128CfbDec;
 use flate2::read::ZlibDecoder;
@@ -31,13 +31,10 @@ where
     }
 }
 
-fn packet_decoder<P: ProtocolPacket>(
-    stream: &mut impl Read,
-    flow: &PacketFlow,
-) -> Result<P, String> {
+fn packet_decoder<P: ProtocolPacket>(stream: &mut impl Read) -> Result<P, String> {
     // Packet ID
     let packet_id = stream.read_varint()?;
-    P::read(packet_id.try_into().unwrap(), flow, stream)
+    P::read(packet_id.try_into().unwrap(), stream)
 }
 
 // this is always true in multiplayer, false in singleplayer
@@ -121,7 +118,6 @@ where
 }
 
 pub async fn read_packet<'a, P: ProtocolPacket, R>(
-    flow: &PacketFlow,
     stream: &'a mut R,
     compression_threshold: Option<u32>,
     cipher: &mut Option<Aes128CfbDec>,
@@ -150,7 +146,7 @@ where
     }
 
     // println!("decoding packet ({}ms)", start_time.elapsed().as_millis());
-    let packet = packet_decoder(&mut buf.as_slice(), flow)?;
+    let packet = packet_decoder(&mut buf.as_slice())?;
     // println!("decoded packet ({}ms)", start_time.elapsed().as_millis());
 
     Ok(packet)


### PR DESCRIPTION
Previously structs like "GamePacket" contained stuff for both clientbound and serverbound packets. This doesn't actually make that much sense and causes some slight issues like matching for packets having to always have a wildcard.