### PR TITLE
refactor: remove println statements

### DIFF
--- a/azalea-auth/src/cache.rs
+++ b/azalea-auth/src/cache.rs
@@ -71,7 +71,7 @@ async fn get_entire_cache(cache_file: &Path) -> Result<Vec<CachedAccount>, Cache
     Ok(cache)
 }
 async fn set_entire_cache(cache_file: &Path, cache: Vec<CachedAccount>) -> Result<(), CacheError> {
-    println!("saving cache: {:?}", cache);
+    log::trace!("saving cache: {:?}", cache);
 
     let mut cache_file = File::create(cache_file).await.map_err(CacheError::Write)?;
     let cache = serde_json::to_string_pretty(&cache).map_err(CacheError::Parse)?;

--- a/azalea-auth/src/sessionserver.rs
+++ b/azalea-auth/src/sessionserver.rs
@@ -51,7 +51,6 @@ pub async fn join(
         "selectedProfile": undashed_uuid,
         "serverId": server_hash
     });
-    println!("data: {:?}", data);
     let res = client
         .post("https://sessionserver.mojang.com/session/minecraft/join")
         .json(&data)

--- a/azalea-brigadier/src/command_dispatcher.rs
+++ b/azalea-brigadier/src/command_dispatcher.rs
@@ -231,7 +231,6 @@ impl<S> CommandDispatcher<S> {
             for context in contexts.iter() {
                 let child = &context.child;
                 if let Some(child) = child {
-                    println!("aaaaaaa {:?}", child);
                     forked |= child.forks;
                     if child.has_nodes() {
                         found_command = true;

--- a/azalea-client/src/movement.rs
+++ b/azalea-client/src/movement.rs
@@ -144,9 +144,10 @@ impl Client {
         let mut entity = player
             .entity_mut(&mut dimension_lock)
             .ok_or(MovePlayerError::PlayerNotInWorld)?;
-        println!(
+        log::trace!(
             "move entity bounding box: {} {:?}",
-            entity.id, entity.bounding_box
+            entity.id,
+            entity.bounding_box
         );
 
         entity.move_colliding(&MoverType::Own, movement)?;

--- a/azalea-world/src/chunk_storage.rs
+++ b/azalea-world/src/chunk_storage.rs
@@ -104,7 +104,7 @@ impl ChunkStorage {
         data: &mut Cursor<&[u8]>,
     ) -> Result<(), BufReadError> {
         if !self.in_range(pos) {
-            println!(
+            log::trace!(
                 "Ignoring chunk since it's not in the view range: {}, {}",
                 pos.x, pos.z
             );
@@ -115,7 +115,8 @@ impl ChunkStorage {
             data,
             self.height,
         )?));
-        println!("Loaded chunk {:?}", pos);
+
+        log::trace!("Loaded chunk {:?}", pos);
         self[pos] = Some(chunk);
 
         Ok(())


### PR DESCRIPTION
This PR removes all println statements and logs them on the trace level instead.
Usually, libraries shouldn't print to stdout using println, since there's no control over them.

Some println statements also looked like leftover debug code, which I have removed.
I can add those back if requested.