### PR TITLE
Allow using `azalea-chat` without `azalea-buf` to avoid unstable features

### DIFF
--- a/azalea-chat/Cargo.toml
+++ b/azalea-chat/Cargo.toml
@@ -8,10 +8,13 @@ version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["azalea-buf"]
+
 [dependencies]
 azalea-buf = { path = "../azalea-buf", features = [
     "serde_json",
-], version = "^0.5.0" }
+], version = "^0.5.0", optional = true }
 azalea-language = { path = "../azalea-language", version = "^0.5.0" }
 log = "0.4.17"
 once_cell = "1.16.0"

--- a/azalea-chat/src/component.rs
+++ b/azalea-chat/src/component.rs
@@ -4,6 +4,7 @@ use crate::{
     text_component::TextComponent,
     translatable_component::{StringOrComponent, TranslatableComponent},
 };
+#[cfg(feature = "azalea-buf")]
 use azalea_buf::{BufReadError, McBufReadable, McBufWritable};
 use log::debug;
 use once_cell::sync::Lazy;
@@ -266,6 +267,7 @@ impl<'de> Deserialize<'de> for Component {
     }
 }
 
+#[cfg(feature = "azalea-buf")]
 impl McBufReadable for Component {
     fn read_from(buf: &mut Cursor<&[u8]>) -> Result<Self, BufReadError> {
         let string = String::read_from(buf)?;
@@ -276,6 +278,7 @@ impl McBufReadable for Component {
     }
 }
 
+#[cfg(feature = "azalea-buf")]
 impl McBufWritable for Component {
     fn write_into(&self, buf: &mut impl Write) -> Result<(), std::io::Error> {
         let json = serde_json::to_string(self).unwrap();

--- a/azalea-chat/src/style.rs
+++ b/azalea-chat/src/style.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fmt};
 
+#[cfg(feature = "azalea-buf")]
 use azalea_buf::McBuf;
 use once_cell::sync::Lazy;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
@@ -86,7 +87,8 @@ impl Ansi {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, McBuf)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(feature = "azalea-buf", derive(McBuf))]
 pub enum ChatFormatting {
     Black,
     DarkBlue,


### PR DESCRIPTION
We'd like to use `azalea-chat` in a custom bot to render colored text, but using the stable compiler (https://github.com/booleancoercion/ferrisquery/pull/1). We're not relying on the `azalea-buf` functionality for this so just disabling that and relying on the json serialization works fine for us. I'm not sure whether this is something you'd want to support upstream, we're fine just relying on a fork if not.

This is technically a breaking change for any users that had `azalea-chat.default-features = false` and were relying on the `azalea-buf`` functionality.