### PR TITLE
derive `Debug` for `BlockState`

### DIFF
--- a/azalea-block/Cargo.toml
+++ b/azalea-block/Cargo.toml
@@ -6,6 +6,9 @@ name = "azalea-block"
 repository = "https://github.com/mat-1/azalea/tree/main/azalea-block"
 version = "0.5.0"
 
+[features]
+full-debug = ["azalea-block-macros/full-debug"]
+
 [lib]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/azalea-block/README.md
+++ b/azalea-block/README.md
@@ -8,3 +8,5 @@ There's two main things here, the `BlockState` enum and the `Block` trait.
 Every block is a struct that implements `Block`. You can freely convert between `BlockState` and `Block` with .into().
 
 If you don't want the `Block` trait, set default-features to false.
+
+Also, by default the `Debug` implementation for `BlockState` only logs the name of the block and not the name of the enum variant. If you want that, enable the `full-debug` feature (though it's not recommended).

--- a/azalea-block/azalea-block-macros/Cargo.toml
+++ b/azalea-block/azalea-block-macros/Cargo.toml
@@ -6,6 +6,9 @@ name = "azalea-block-macros"
 repository = "https://github.com/mat-1/azalea/tree/main/azalea-block/azalea-block-macros"
 version = "0.5.0"
 
+[features]
+full-debug = []
+
 [lib]
 proc-macro = true
 

--- a/azalea-block/azalea-block-macros/src/lib.rs
+++ b/azalea-block/azalea-block-macros/src/lib.rs
@@ -580,8 +580,7 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
         #[cfg(not(feature = "full-debug"))]
         impl std::fmt::Debug for BlockState {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                // having a big match statement here would take up 700kb
-                f.write_str("BlockState (enable full-debug feature to see block)")
+                write!(f, "BlockState ({})", Box::<dyn Block>::from(*self).id())
             }
         }
     };

--- a/azalea-block/azalea-block-macros/src/lib.rs
+++ b/azalea-block/azalea-block-macros/src/lib.rs
@@ -563,6 +563,8 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
 
         #[repr(u32)]
         #[derive(Copy, Clone, PartialEq, Eq)]
+        // the Debug impl is very large and slows down compilation
+        #[cfg_attr(feature = "full-debug", derive(Debug))]
         pub enum BlockState {
             #block_state_enum_variants
         }
@@ -575,10 +577,11 @@ pub fn make_block_states(input: TokenStream) -> TokenStream {
             }
         }
 
+        #[cfg(not(feature = "full-debug"))]
         impl std::fmt::Debug for BlockState {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 // having a big match statement here would take up 700kb
-                f.write_str("BlockState")
+                f.write_str("BlockState (enable full-debug feature to see block)")
             }
         }
     };

--- a/azalea-block/src/lib.rs
+++ b/azalea-block/src/lib.rs
@@ -74,4 +74,13 @@ mod tests {
         let block: Box<dyn Block> = Box::<dyn Block>::from(BlockState::FloweringAzalea);
         assert_eq!(block.id(), "flowering_azalea");
     }
+
+    #[cfg(not(feature = "full-debug"))]
+    #[test]
+    fn test_debug_blockstate() {
+        assert_eq!(
+            format!("{:?}", BlockState::FloweringAzalea),
+            "BlockState (flowering_azalea)"
+        );
+    }
 }


### PR DESCRIPTION
When I want to know what block is at a position, I cannot because the `Debug` impl does not not produce the name of the block. With this change, I get the desired output.