### PR TITLE
fix `BlockCollisions` bounding box

### DIFF
--- a/azalea-physics/src/collision/world_collisions.rs
+++ b/azalea-physics/src/collision/world_collisions.rs
@@ -20,13 +20,13 @@ pub struct BlockCollisions<'a> {
 
 impl<'a> BlockCollisions<'a> {
     pub fn new(world: &'a World, aabb: AABB) -> Self {
-        let origin_x = (aabb.min_x - EPSILON) as i32 - 1;
-        let origin_y = (aabb.min_y - EPSILON) as i32 - 1;
-        let origin_z = (aabb.min_z - EPSILON) as i32 - 1;
+        let origin_x = (aabb.min_x - EPSILON).floor() as i32 - 1;
+        let origin_y = (aabb.min_y - EPSILON).floor() as i32 - 1;
+        let origin_z = (aabb.min_z - EPSILON).floor() as i32 - 1;
 
-        let end_x = (aabb.max_x + EPSILON) as i32 + 1;
-        let end_y = (aabb.max_y + EPSILON) as i32 + 1;
-        let end_z = (aabb.max_z + EPSILON) as i32 + 1;
+        let end_x = (aabb.max_x + EPSILON).floor() as i32 + 1;
+        let end_y = (aabb.max_y + EPSILON).floor() as i32 + 1;
+        let end_z = (aabb.max_z + EPSILON).floor() as i32 + 1;
 
         let cursor = Cursor3d::new(origin_x, origin_y, origin_z, end_x, end_y, end_z);
 

--- a/azalea-physics/src/lib.rs
+++ b/azalea-physics/src/lib.rs
@@ -596,4 +596,65 @@ mod tests {
         let entity_pos = app.world.get::<Position>(entity).unwrap();
         assert_eq!(entity_pos.y, 70.5);
     }
+
+    #[test]
+    fn test_negative_coordinates_weird_wall_collision() {
+        let mut app = make_test_app();
+        let world_lock = app.world.resource_mut::<WorldContainer>().insert(
+            ResourceLocation::new("minecraft:overworld").unwrap(),
+            384,
+            -64,
+        );
+        let mut partial_world = PartialWorld::default();
+
+        partial_world.chunks.set(
+            &ChunkPos { x: -1, z: -1 },
+            Some(Chunk::default()),
+            &mut world_lock.write().chunks,
+        );
+        let entity = app
+            .world
+            .spawn((
+                EntityBundle::new(
+                    Uuid::nil(),
+                    Vec3 {
+                        x: -7.5,
+                        y: 73.,
+                        z: -7.5,
+                    },
+                    azalea_registry::EntityKind::Player,
+                    ResourceLocation::new("minecraft:overworld").unwrap(),
+                ),
+                MinecraftEntityId(0),
+                Local,
+            ))
+            .id();
+        let block_state = world_lock.write().chunks.set_block_state(
+            &BlockPos {
+                x: -8,
+                y: 69,
+                z: -8,
+            },
+            azalea_block::CobblestoneWallBlock {
+                east: azalea_block::EastWall::Low,
+                north: azalea_block::NorthWall::Low,
+                south: azalea_block::SouthWall::Low,
+                west: azalea_block::WestWall::Low,
+                up: false,
+                waterlogged: false,
+            }
+            .into(),
+        );
+        assert!(
+            block_state.is_some(),
+            "Block state should exist, if this fails that means the chunk wasn't loaded and the block didn't get placed"
+        );
+        // do a few steps so we fall on the slab
+        for _ in 0..20 {
+            app.update();
+        }
+
+        let entity_pos = app.world.get::<Position>(entity).unwrap();
+        assert_eq!(entity_pos.y, 70.5);
+    }
 }


### PR DESCRIPTION
When the bot is moving it will sometimes think it is not on the ground which will cause it to move only very slowly. The coordinates of the bounding box should be floored because that gives the correct block position.