### PR TITLE
Created nearest_entity system param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 flamegraph.svg
 perf.data
 perf.data.old
+.vscode
 
 # created by azalea-auth/examples/auth, defined in the main .gitignore because
 # the example could be run from anywhere

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"editor.formatOnSave": true
-}

--- a/azalea-chat/src/translatable_component.rs
+++ b/azalea-chat/src/translatable_component.rs
@@ -133,7 +133,10 @@ impl Display for TranslatableComponent {
         for component in FormattedText::Translatable(self.clone()).into_iter() {
             let component_text = match &component {
                 FormattedText::Text(c) => c.text.to_string(),
-                FormattedText::Translatable(c) => c.read()?.to_string(),
+                FormattedText::Translatable(c) => match c.read() {
+                    Ok(c) => c.to_string(),
+                    Err(_) => c.key.to_string(),
+                },
             };
 
             f.write_str(&component_text)?;

--- a/azalea-client/src/client.rs
+++ b/azalea-client/src/client.rs
@@ -7,7 +7,7 @@ use crate::{
     inventory::{InventoryComponent, InventoryPlugin},
     local_player::{
         death_event, handle_send_packet_event, update_in_loaded_chunk, GameProfileComponent,
-        LocalPlayer, PhysicsState, SendPacketEvent,
+        Hunger, LocalPlayer, PhysicsState, SendPacketEvent,
     },
     mining::{self, MinePlugin},
     movement::{LastSentLookDirection, PlayerMovePlugin},
@@ -564,6 +564,14 @@ impl Client {
     /// This is a shortcut for `*bot.component::<Health>()`.
     pub fn health(&self) -> f32 {
         *self.component::<Health>()
+    }
+
+    /// Get the hunger level of this client, which includes both food and
+    /// saturation.
+    ///
+    /// This is a shortcut for `self.component::<Hunger>().to_owned()`.
+    pub fn hunger(&self) -> Hunger {
+        self.component::<Hunger>().to_owned()
     }
 }
 

--- a/azalea-client/src/local_player.rs
+++ b/azalea-client/src/local_player.rs
@@ -89,6 +89,16 @@ pub struct LocalGameMode {
     pub previous: Option<GameMode>,
 }
 
+#[derive(Component, Clone)]
+pub struct Hunger {
+    /// The main hunger bar. Goes from 0 to 20.
+    pub food: u32,
+    /// The amount of saturation the player has. This isn't shown in normal
+    /// vanilla clients but it's a separate counter that makes it so your hunger
+    /// only starts decreasing when this is 0.
+    pub saturation: f32,
+}
+
 impl LocalPlayer {
     /// Create a new `LocalPlayer`.
     pub fn new(

--- a/azalea-entity/src/lib.rs
+++ b/azalea-entity/src/lib.rs
@@ -229,7 +229,7 @@ pub struct Dead;
 /// coordinates.
 ///
 /// This is used to calculate the camera position for players, when spectating
-/// an entity, and when raytracing from the entity.
+/// an entity, and when raycasting from the entity.
 #[derive(Component, Clone, Copy, Debug, PartialEq, Deref, DerefMut)]
 pub struct EyeHeight(f32);
 impl From<EyeHeight> for f32 {

--- a/azalea/examples/nearest_entity.rs
+++ b/azalea/examples/nearest_entity.rs
@@ -1,0 +1,54 @@
+use azalea::nearest_entity::EntityFinder;
+use azalea::ClientBuilder;
+use azalea::{Bot, LookAtEvent};
+use azalea_client::Account;
+use azalea_entity::{EyeHeight, Position};
+use bevy_app::{FixedUpdate, Plugin};
+use bevy_ecs::{
+    prelude::{Entity, EventWriter},
+    query::With,
+    system::Query,
+};
+
+#[tokio::main]
+async fn main() {
+    let account = Account::offline("bot");
+
+    ClientBuilder::new()
+        .add_plugins(LookAtStuffPlugin)
+        .start(account, "localhost")
+        .await
+        .unwrap();
+}
+
+pub struct LookAtStuffPlugin;
+impl Plugin for LookAtStuffPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_systems(FixedUpdate, look_at_everything);
+    }
+}
+
+fn look_at_everything(
+    bots: Query<Entity, With<Bot>>,
+    entities: EntityFinder,
+    entity_positions: Query<(&Position, Option<&EyeHeight>)>,
+    mut look_at_event: EventWriter<LookAtEvent>,
+) {
+    for bot_id in bots.iter() {
+        let Some(entity) = entities.nearest_to_entity(bot_id, 16.0) else {
+            continue;
+        };
+
+        let (position, eye_height) = entity_positions.get(entity).unwrap();
+
+        let mut look_target = **position;
+        if let Some(eye_height) = eye_height {
+            look_target.y += **eye_height as f64;
+        }
+
+        look_at_event.send(LookAtEvent {
+            entity: bot_id,
+            position: look_target,
+        });
+    }
+}

--- a/azalea/examples/nearest_entity.rs
+++ b/azalea/examples/nearest_entity.rs
@@ -17,7 +17,7 @@ async fn main() {
 
     ClientBuilder::new()
         .add_plugins(LookAtStuffPlugin)
-        .start(account, "localhost:34071")
+        .start(account, "localhost")
         .await
         .unwrap();
 }
@@ -30,7 +30,7 @@ impl Plugin for LookAtStuffPlugin {
 }
 
 fn look_at_everything(
-    bots: Query<Entity, With<Bot>>,
+    bots: Query<Entity, (With<Local>, With<Player>)>,
     entities: EntityFinder,
     entity_positions: Query<(&Position, Option<&EyeHeight>)>,
     mut look_at_event: EventWriter<LookAtEvent>,

--- a/azalea/examples/nearest_entity.rs
+++ b/azalea/examples/nearest_entity.rs
@@ -2,8 +2,8 @@ use azalea::nearest_entity::EntityFinder;
 use azalea::ClientBuilder;
 use azalea::{Bot, LookAtEvent};
 use azalea_client::Account;
-use azalea_entity::metadata::{Item, ItemItem};
-use azalea_entity::{EyeHeight, Position};
+use azalea_entity::metadata::{ItemItem, Player};
+use azalea_entity::{EyeHeight, Local, Position};
 use bevy_app::{FixedUpdate, Plugin};
 use bevy_ecs::{
     prelude::{Entity, EventWriter},

--- a/azalea/src/lib.rs
+++ b/azalea/src/lib.rs
@@ -22,7 +22,7 @@ pub use azalea_entity as entity;
 pub use azalea_protocol as protocol;
 pub use azalea_registry::{Block, EntityKind, Item};
 pub use azalea_world as world;
-pub use bot::DefaultBotPlugins;
+pub use bot::*;
 use ecs::component::Component;
 use futures::{future::BoxFuture, Future};
 use protocol::{

--- a/azalea/src/lib.rs
+++ b/azalea/src/lib.rs
@@ -7,6 +7,7 @@
 mod auto_respawn;
 mod bot;
 pub mod container;
+pub mod nearest_entity;
 pub mod pathfinder;
 pub mod prelude;
 pub mod swarm;

--- a/azalea/src/nearest_entity.rs
+++ b/azalea/src/nearest_entity.rs
@@ -14,11 +14,11 @@ use bevy_ecs::{
 /// All functions used by this system parameter instance will respect the
 /// applied filter.
 ///
-/// ```no_run
+/// ```
 /// /// All bots near aggressive mobs will scream in chat.
 /// pub fn bots_near_aggressive_mobs(
 ///     bots: Query<Entity, With<Bot>>,
-///     entity_finder: EntityFinder<With<Aggressive>>,
+///     entity_finder: EntityFinder<With<AbstractMonster>>,
 ///     chat_events: EventWriter<SendChatEvent>,
 /// ) {
 ///     for bot_id in bots.iter() {

--- a/azalea/src/nearest_entity.rs
+++ b/azalea/src/nearest_entity.rs
@@ -1,0 +1,112 @@
+use azalea_entity::Position;
+use azalea_world::{InstanceName, MinecraftEntityId};
+use bevy_ecs::{
+    prelude::Entity,
+    query::{ReadOnlyWorldQuery, With},
+    system::{Query, SystemParam},
+};
+
+/// This system parameter can be used as a shorthand for quickly finding an
+/// entity, (or several) close to a given position.
+///
+/// This system parameter allows for additional filtering of entities based off
+/// of ECS marker components, such as `With<>`, `Without<>`, or `Added<>`, etc.
+/// All functions used by this system parameter instance will respect the
+/// applied filter.
+///
+/// ```no_run
+/// /// All bots near aggressive mobs will scream in chat.
+/// pub fn bots_near_aggressive_mobs(
+///     bots: Query<Entity, With<Bot>>,
+///     entity_finder: EntityFinder<With<Aggressive>>,
+///     chat_events: EventWriter<SendChatEvent>,
+/// ) {
+///     for bot_id in bots.iter() {
+///         let Some(nearest) = entity_finder.nearest_to_entity(bot_id, 16.0) else {
+///             continue;
+///         }
+///
+///         chat_events.send(SendChatEvent {
+///             entity: bot_id,
+///             content: String::from("Ahhh!"),
+///         })
+///     }
+/// }
+/// ```
+#[derive(SystemParam)]
+pub struct EntityFinder<'w, 's, F = ()>
+where
+    F: ReadOnlyWorldQuery + 'static,
+{
+    all_entities:
+        Query<'w, 's, (&'static Position, &'static InstanceName), With<MinecraftEntityId>>,
+
+    filtered_entities: Query<
+        'w,
+        's,
+        (Entity, &'static InstanceName, &'static Position),
+        (With<MinecraftEntityId>, F),
+    >,
+}
+
+impl<'w, 's, 'a, F> EntityFinder<'w, 's, F>
+where
+    F: ReadOnlyWorldQuery + 'static,
+{
+    /// Gets the nearest entity to the given position and world instance name.
+    /// This method will return `None` if there are no entities within range. If
+    /// multiple entities are within range, only the closest one is returned.
+    pub fn nearest_to_position(
+        &'a self,
+        position: &Position,
+        instance_name: &InstanceName,
+        max_distance: f64,
+    ) -> Option<Entity> {
+        let mut nearest_entity = None;
+        let mut min_distance = max_distance;
+
+        for (target_entity, e_instance, e_pos) in self.filtered_entities.iter() {
+            if e_instance != instance_name {
+                continue;
+            }
+
+            let target_distance = position.distance_to(e_pos);
+            if target_distance < min_distance {
+                nearest_entity = Some(target_entity);
+                min_distance = target_distance;
+            }
+        }
+
+        nearest_entity
+    }
+
+    /// Gets the nearest entity to the given entity. This method will return
+    /// `None` if there are no entities within range. If multiple entities are
+    /// within range, only the closest one is returned.
+    pub fn nearest_to_entity(&'a self, entity: Entity, max_distance: f64) -> Option<Entity> {
+        let Ok((position, instance_name)) = self.all_entities.get(entity) else {
+            return None;
+        };
+
+        let mut nearest_entity = None;
+        let mut min_distance = max_distance;
+
+        for (target_entity, e_instance, e_pos) in self.filtered_entities.iter() {
+            if entity == target_entity {
+                continue;
+            };
+
+            if e_instance != instance_name {
+                continue;
+            }
+
+            let target_distance = position.distance_to(e_pos);
+            if target_distance < min_distance {
+                nearest_entity = Some(target_entity);
+                min_distance = target_distance;
+            }
+        }
+
+        nearest_entity
+    }
+}

--- a/azalea/src/nearest_entity.rs
+++ b/azalea/src/nearest_entity.rs
@@ -109,4 +109,73 @@ where
 
         nearest_entity
     }
+
+    /// This function get an iterator over all nearby entities to the given
+    /// position within the given maximum distance. The entities in this
+    /// iterator are not returned in any specific order.
+    ///
+    /// This function returns the Entity ID of nearby entities and their
+    /// distance away.
+    pub fn nearby_entities_to_position(
+        &'a self,
+        position: &'a Position,
+        instance_name: &'a InstanceName,
+        max_distance: f64,
+    ) -> impl Iterator<Item = (Entity, f64)> + '_ {
+        self.filtered_entities
+            .iter()
+            .filter_map(move |(target_entity, e_instance, e_pos)| {
+                if e_instance != instance_name {
+                    return None;
+                }
+
+                let distance = position.distance_to(e_pos);
+                if distance < max_distance {
+                    Some((target_entity, distance))
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// This function get an iterator over all nearby entities to the given
+    /// entity within the given maximum distance. The entities in this iterator
+    /// are not returned in any specific order.
+    ///
+    /// This function returns the Entity ID of nearby entities and their
+    /// distance away.
+    pub fn nearby_entities_to_entity(
+        &'a self,
+        entity: Entity,
+        max_distance: f64,
+    ) -> impl Iterator<Item = (Entity, f64)> + '_ {
+        let position;
+        let instance_name;
+        if let Ok((pos, instance)) = self.all_entities.get(entity) {
+            position = *pos;
+            instance_name = Some(instance);
+        } else {
+            position = Position::default();
+            instance_name = None;
+        };
+
+        self.filtered_entities
+            .iter()
+            .filter_map(move |(target_entity, e_instance, e_pos)| {
+                if entity == target_entity {
+                    return None;
+                }
+
+                if Some(e_instance) != instance_name {
+                    return None;
+                }
+
+                let distance = position.distance_to(e_pos);
+                if distance < max_distance {
+                    Some((target_entity, distance))
+                } else {
+                    None
+                }
+            })
+    }
 }

--- a/azalea/src/nearest_entity.rs
+++ b/azalea/src/nearest_entity.rs
@@ -15,21 +15,29 @@ use bevy_ecs::{
 /// applied filter.
 ///
 /// ```
+/// use azalea::chat::SendChatEvent;
+/// use azalea::nearest_entity::EntityFinder;
+/// use azalea_entity::metadata::{Player, AbstractMonster};
+/// use azalea_entity::Local;
+/// use bevy_ecs::system::Query;
+/// use bevy_ecs::prelude::{Entity, EventWriter};
+/// use bevy_ecs::query::With;
+///
 /// /// All bots near aggressive mobs will scream in chat.
 /// pub fn bots_near_aggressive_mobs(
-///     bots: Query<Entity, With<Bot>>,
+///     bots: Query<Entity, (With<Local>, With<Player>)>,
 ///     entity_finder: EntityFinder<With<AbstractMonster>>,
-///     chat_events: EventWriter<SendChatEvent>,
+///     mut chat_events: EventWriter<SendChatEvent>,
 /// ) {
 ///     for bot_id in bots.iter() {
 ///         let Some(nearest) = entity_finder.nearest_to_entity(bot_id, 16.0) else {
 ///             continue;
-///         }
+///         };
 ///
 ///         chat_events.send(SendChatEvent {
 ///             entity: bot_id,
 ///             content: String::from("Ahhh!"),
-///         })
+///         });
 ///     }
 /// }
 /// ```

--- a/azalea/src/swarm/mod.rs
+++ b/azalea/src/swarm/mod.rs
@@ -159,13 +159,13 @@ where
     pub fn set_handler<S, Fut>(self, handler: HandleFn<S, Fut>) -> SwarmBuilder<S, SS>
     where
         Fut: Future<Output = Result<(), anyhow::Error>> + Send + 'static,
-        S: Send + Sync + Clone + Component + 'static,
+        S: Send + Sync + Clone + Component + Default + 'static,
     {
         SwarmBuilder {
             handler: Some(Box::new(move |bot, event, state: S| {
                 Box::pin(handler(bot, event, state))
             })),
-            states: Vec::new(),
+            states: vec![S::default(); self.accounts.len()],
             app: self.app,
             ..self
         }


### PR DESCRIPTION
This utility function (provided as a `SystemParam` for easier Bevy system integration) can be used to locate nearby entities using much less boilerplate code.

_Note that the example in this PR relies on #101 for sending LookAt events._